### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <!--next-version-placeholder-->
 
+## v0.1.4 (20/10/2025)
+
+### Changed
+- **Documentation**: Updated mkdocs navigation to include new examples
+- **Documentation**: Complete documentation site structure with all v0.1.2+ features
+
+### Fixed  
+- **Documentation**: Missing navigation entries for task replication and workflow examples
+
 ## v0.1.3 (20/10/2025)
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,7 @@
 site_name: NeoPipe Documentation
+docs_dir: docs
+site_dir: site
+
 nav:
   - Home: index.md
   - Examples: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,9 @@ exclude_lines = [
 
 [tool.hatch.envs.docs]
 dependencies = [
-  "mkdocs"
+  "mkdocs",
+  "mkdocs-material", 
+  "mkdocstrings[python]"
 ]
 
 [tool.hatch.envs.docs.scripts]

--- a/src/neopipe/__about__.py
+++ b/src/neopipe/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present MrDataPsycho <mr.data.psycho@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
docs: complete mkdocs navigation for new examples

Fix missing navigation entries for task replication and workflow examples.
Bump version to 0.1.4.